### PR TITLE
Upped the default manual system handler priority and added some new e…

### DIFF
--- a/src/EcsR3.Plugins.Views/Systems/PooledViewResolverSystem.cs
+++ b/src/EcsR3.Plugins.Views/Systems/PooledViewResolverSystem.cs
@@ -9,7 +9,7 @@ using EcsR3.Systems;
 
 namespace EcsR3.Plugins.Views.Systems
 {
-    public abstract class PooledViewResolverSystem : IViewResolverSystem, IManualSystem, IGroupSystem
+    public abstract class PooledViewResolverSystem : IViewResolverSystem, IManualSystem
     {
         public IEventSystem EventSystem { get; }
 

--- a/src/EcsR3.Tests/Sanity/SanityTests.cs
+++ b/src/EcsR3.Tests/Sanity/SanityTests.cs
@@ -182,6 +182,27 @@ namespace EcsR3.Tests.Sanity
             Assert.True(setupCalled);
             Assert.True(teardownCalled);
         }
+        
+        [Fact]
+        public void should_call_setup_system_before_setup_and_teardown_for_entities_on_view_system()
+        {
+            var (observableGroupManager, entityDatabase, _, _) = CreateFramework();
+            var executor = CreateExecutor(observableGroupManager);
+
+            var expectedCallList = new[] { "start-system", "setup", "teardown", "stop-system" };
+            var actualCallList = new List<string>();
+            
+            var viewResolverSystem = new HybridSetupSystem(actualCallList.Add, new Group(typeof(TestComponentOne), typeof(ViewComponent)));
+            var collection = entityDatabase.GetCollection();
+            var entityOne = collection.CreateEntity();
+            entityOne.AddComponents(new TestComponentOne(), new ViewComponent());
+            
+            executor.AddSystem(viewResolverSystem);
+            collection.RemoveEntity(entityOne.Id);
+            executor.RemoveSystem(viewResolverSystem);
+
+            Assert.Equal(expectedCallList, actualCallList);
+        }
 
         [Fact]
         public void should_listen_to_multiple_collections_for_updates()

--- a/src/EcsR3.Tests/Systems/HybridSetupSystem.cs
+++ b/src/EcsR3.Tests/Systems/HybridSetupSystem.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using EcsR3.Entities;
+using EcsR3.Groups;
+using EcsR3.Systems;
+using SystemsR3.Systems.Conventional;
+
+namespace EcsR3.Tests.Systems;
+
+public class HybridSetupSystem : ISetupSystem, ITeardownSystem, IManualSystem
+{
+    public IGroup Group { get; }
+
+    public Action<string> OnMethodCalled { get; }
+
+    public HybridSetupSystem(Action<string> onMethodCalled, IGroup group)
+    {
+        Group = group;
+        OnMethodCalled = onMethodCalled;
+    }
+
+    public void Setup(IEntity entity)
+    {
+        OnMethodCalled("setup");
+    }
+    
+    public void Teardown(IEntity entity)
+    {
+        OnMethodCalled("teardown");
+    }
+    
+    public void StartSystem()
+    {
+        OnMethodCalled("start-system");
+    }
+
+    public void StopSystem()
+    {
+        OnMethodCalled("stop-system");
+    }
+}

--- a/src/SystemsR3/Executor/Handlers/Conventional/ManualSystemHandler.cs
+++ b/src/SystemsR3/Executor/Handlers/Conventional/ManualSystemHandler.cs
@@ -4,7 +4,7 @@ using SystemsR3.Systems.Conventional;
 
 namespace SystemsR3.Executor.Handlers.Conventional
 {
-    [Priority(5)]
+    [Priority(100)]
     public class ManualSystemHandler : IConventionalSystemHandler
     {
         public bool CanHandleSystem(ISystem system)


### PR DESCRIPTION
…xtensions

This was causing an issue where entities existed for a given setup system, but it needed to run the IManualSystem part first to setup its view pooling.