### PR TITLE
Fixing bug for pooled views starting off active rather than inactive

### DIFF
--- a/src/EcsR3.Plugins.Views/Pools/ViewPool.cs
+++ b/src/EcsR3.Plugins.Views/Pools/ViewPool.cs
@@ -14,7 +14,11 @@ namespace EcsR3.Plugins.Views.Pools
         }
 
         public override object Create()
-        { return ViewHandler.CreateView(); }
+        {
+            var instance = ViewHandler.CreateView();
+            ViewHandler.SetActiveState(instance, false);
+            return instance;
+        }
 
         public override void Destroy(object instance)
         { ViewHandler.DestroyView(instance); }

--- a/src/EcsR3.Tests/Plugins/Views/ViewPoolTests.cs
+++ b/src/EcsR3.Tests/Plugins/Views/ViewPoolTests.cs
@@ -10,7 +10,7 @@ namespace EcsR3.Tests.Plugins.Views;
 public class ViewPoolTests
 {
     [Fact]
-    public void should_get_view_handler_to_create_instances()
+    public void should_get_view_handler_to_create_instance_and_set_to_false_on_creation()
     {
         var mockViewHandler = Substitute.For<IViewHandler>();
         mockViewHandler.CreateView().Returns(new object());
@@ -21,6 +21,7 @@ public class ViewPoolTests
         var instance = viewPool.Allocate();
         
         mockViewHandler.Received(2).CreateView();
+        mockViewHandler.Received(poolConfig.InitialSize).SetActiveState(Arg.Any<object>(), false);
         Assert.NotNull(instance);
     }
     
@@ -52,6 +53,6 @@ public class ViewPoolTests
         viewPool.Release(instance);
         
         mockViewHandler.Received(1).SetActiveState(Arg.Any<object>(), true);
-        mockViewHandler.Received(1).SetActiveState(Arg.Any<object>(), false);
+        mockViewHandler.Received(poolConfig.InitialSize+1).SetActiveState(Arg.Any<object>(), false);
     }
 }


### PR DESCRIPTION
Minor fix for adding the default state of created view pools to false, only realised this was an issue in the Unity layer.